### PR TITLE
support "gen_tcp:connect" options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 1.0.17
+
+* Support "gen_tcp" connect options (ie. keepalive, send_timeout, sndbuf, recbuf...) 
+
+# Version 1.0.16
+
+* Support OTP-23 on travis
+
 # Version 1.0.15
 
 * Fix warnings

--- a/src/p1_mysql_conn.erl
+++ b/src/p1_mysql_conn.erl
@@ -330,7 +330,7 @@ do_recv(LogFun, RecvPid, SeqNum) when is_function(LogFun);
 %% Returns : void() | does not return
 %%--------------------------------------------------------------------
 init(Host, Port, User, Password, Database, ConnectTimeout, LogFun, Parent, SSLOpts) ->
-    case p1_mysql_recv:start_link(Host, Port, ConnectTimeout, LogFun, self()) of
+    case p1_mysql_recv:start_link(Host, Port, ConnectTimeout, LogFun, self(), SSLOpts) of
 	{ok, RecvPid, Sock0} ->
 	    case mysql_init(Sock0, RecvPid, User, Password, LogFun, SSLOpts) of
 		{ok, {SockMod, RawSock} = Sock, Version} ->


### PR DESCRIPTION
I believe some TCP settings should be configureable :

- send_timeout : its default value "infinity" could be tricky
- keepalive
- sndbuf & recbuf : those sizes may have performance impacts

see https://erlang.org/doc/man/inet.html#setopts-2


NOTE: The SSLOpts variable in p1_mysql_conn may be renamed Opts or Options

1) "proplists:get_bool(prop, Opts)" calls could be replace by "get_option(prop, Opts, false)" calls 

2) "get_option" works even if some properties are not keyvalues, for instance : 

get_option(ssl_required, [keepalive, {send_timeout, 5000}, {ssl_required, true}], false).
true
