### PR TITLE
Fix error decoding for prepared statement execution

### DIFF
--- a/src/p1_mysql_bin.erl
+++ b/src/p1_mysql_bin.erl
@@ -124,7 +124,7 @@ get_execute_stmt_response(State, Version, _Options) ->
 	{ok, <<T:8, Rest/binary>>, _, NState} when T == 0; T == 254 ->
 	    {AffectedRows, _} = decode_var_int(Rest),
 	    {updated, #p1_mysql_result{affectedrows = AffectedRows}, NState};
-	{ok, <<255, _ErrCode:16/little, _StateMarker:8/binary, _State:40/binary, Rest/binary>>, _, _NState}
+	{ok, <<255, _ErrCode:16/little, $#, _State:5/binary, Rest/binary>>, _, _NState}
 	    when Version == ?MYSQL_4_1 ->
 	    {error, #p1_mysql_result{error = binary_to_list(Rest)}};
 	{ok, <<255, _ErrCode:16/little, Rest/binary>>, _, _NState} ->
@@ -162,7 +162,7 @@ get_prepare_response(State, Version, _Options) ->
 		    end;
 		E -> E
 	    end;
-	{ok, <<255, _ErrCode:16/little, _StateMarker:1/binary, _State:5/binary, Rest/binary>>, _, NState}
+	{ok, <<255, _ErrCode:16/little, $#, _State:5/binary, Rest/binary>>, _, NState}
 	    when Version == ?MYSQL_4_1 ->
 	    {error, NState, #p1_mysql_result{error = binary_to_list(Rest)}};
 	{ok, <<255, _ErrCode:16/little, Rest/binary>>, _, NState} ->


### PR DESCRIPTION
The decoding of the buffer containing an error in `get_execute_stmt_response()` should be the same as in `get_prepare_response()` in `p1_mysql_bin.erl`

For example on such an error 
https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_data_too_long

The decoding is currently incorrect :

```erlang
erl> {ok, <<255, _ErrCode:16/little, _StateMarker:8/binary, _State:40/binary, Rest/binary>>, _, _NState} =
{ok, <<255,126,5,35,50,50,48,48,49,68,97,116,97,32,116,111,111,32,108,111,110,103,32,102,111,114,32,99,111,108,117,109,110,32,39,108,110,105,99,107,110,97,109, 101,39,32,97,116,32,114,111,119,32,49>>, 1, {state}}.
{ok,<<255,126,5,35,50,50,48,48,49,68,97,116,97,32,116,111,
      111,32,108,111,110,103,32,102,111,114,32,...>>, 1, {state}}

erl> _ErrCode.
1406
erl> _StateMarker.
<<"#22001Da">>
erl> _State.
<<"ta too long for column 'lnickname' at ro">>
erl> Rest.
<<"w 1">>
```

it should be :

```erlang
{ok, <<255, _ErrCode:16/little, $#, _State:5/binary, Rest/binary>>, _, _NState} = 
  {ok, <<255,126,5,35,50,50,48,48,49,68,97,116,97,32,116,111,111,32,108,111,110,103,32,102,111,114,32,99,111,108,117,109,110,32,39,108,110,105,99,107,110,97,109, 101,39,32,97,116,32,114,111,119,32,49>>, 1, {state}}.

erl> _ErrCode.
1406
erl> _StateMarker.
<<"#">>
erl> _State.
<<"22001">>
erl> Rest.
<<"Data too long for column 'lnickname' at row 1">>
```