### PR TITLE
fix call to p1_mysql_conn

### DIFF
--- a/src/p1_mysql.erl
+++ b/src/p1_mysql.erl
@@ -302,7 +302,7 @@ connect(Id, Host, Port, User, Password, Database, Reconnect) ->
     connect(Id, Host, Port, User, Password, Database, Reconnect, []).
 connect(Id, Host, Port, User, Password, Database, Reconnect, SSLOpts) ->
     {ok, LogFun} = gen_server:call(?SERVER, get_logfun),
-    case p1_mysql_conn:start(Host, Port, User, Password, Database, LogFun, SSLOpts) of
+    case p1_mysql_conn:start(Host, Port, User, Password, Database,?CONNECT_TIMEOUT, LogFun, SSLOpts) of
 	{ok, ConnPid} ->
 	    MysqlConn =
 		case Reconnect of


### PR DESCRIPTION
This PR fix the call to p1_mysql_conn:start. The timeout argument is missing, and when trying to reconnect, it will fail.

this fix  #20 